### PR TITLE
Update dependency to Orange3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
                 'orangecontrib.spark.widgets': ['icons/*'],
             },
             install_requires = [
-                'Orange',
+                'Orange3',
                 'pandas',
                 'py4j',
                 'sqlparse'


### PR DESCRIPTION
Orange 3 is now available on pypi as Orange3.

This PR updates the install_requires list accordingly.
